### PR TITLE
Make Lame encoder an immediate DS component

### DIFF
--- a/audio-utils/audio-encoder-lame/src/main/resources/OSGI-INF/encoder.xml
+++ b/audio-utils/audio-encoder-lame/src/main/resources/OSGI-INF/encoder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="audio-encoder-lame">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="audio-encoder-lame" immediate="true">
    <implementation class="org.daisy.pipeline.audio.lame.LameEncoder"/>
    <service>
       <provide interface="org.daisy.pipeline.audio.AudioEncoder"/>


### PR DESCRIPTION
I found out that sometimes Lame wasn't registered when invoked. Maybe because the XProc step gets the service _when it registers_ and not on demand _when it executes_. 

To be further investigated, but declaring lame as an immediate component solves it in the short term. 
